### PR TITLE
Convert to having the EIP_MANAGEMENT variable as part of the packetcluster Type

### DIFF
--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -21,6 +21,9 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
+// VIPManagerType describes if the VIP will be managed by CPEM or kube-vip
+type VIPManagerType string
+
 // PacketClusterSpec defines the desired state of PacketCluster
 type PacketClusterSpec struct {
 	// ProjectID represents the Packet Project where this cluster will be placed into
@@ -35,7 +38,9 @@ type PacketClusterSpec struct {
 
 	// VIPManager represents whether this cluster uses CPEM or kube-vip to
 	// manage its vip for the api server IP
-	VIPManager string `json:"vipManager"`
+	// +kubebuilder:validation:Enum=CPEM;KUBE_VIP
+	// +kubebuilder:default:=CPEM
+	VIPManager VIPManagerType `json:"vipManager"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -32,6 +32,10 @@ type PacketClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// EIPManagement represents whether this cluster uses CPEM or kube-vip to
+	// manage its vip for the api server IP
+	EipManagement string `json:"eipmanagement"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -33,9 +33,9 @@ type PacketClusterSpec struct {
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
-	// EIPManagement represents whether this cluster uses CPEM or kube-vip to
+	// VIPManager represents whether this cluster uses CPEM or kube-vip to
 	// manage its vip for the api server IP
-	EipManagement string `json:"eipmanagement"`
+	VIPManager string `json:"vipManager"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -241,7 +241,7 @@ func autoConvert_v1alpha3_PacketClusterSpec_To_v1beta1_PacketClusterSpec(in *Pac
 	if err := apiv1alpha3.Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.EipManagement = in.EipManagement
+	out.VIPManager = in.VIPManager
 	return nil
 }
 
@@ -256,7 +256,7 @@ func autoConvert_v1beta1_PacketClusterSpec_To_v1alpha3_PacketClusterSpec(in *v1b
 	if err := apiv1alpha3.Convert_v1beta1_APIEndpoint_To_v1alpha3_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.EipManagement = in.EipManagement
+	out.VIPManager = in.VIPManager
 	return nil
 }
 

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -241,7 +241,7 @@ func autoConvert_v1alpha3_PacketClusterSpec_To_v1beta1_PacketClusterSpec(in *Pac
 	if err := apiv1alpha3.Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.VIPManager = in.VIPManager
+	out.VIPManager = v1beta1.VIPManagerType(in.VIPManager)
 	return nil
 }
 
@@ -256,7 +256,7 @@ func autoConvert_v1beta1_PacketClusterSpec_To_v1alpha3_PacketClusterSpec(in *v1b
 	if err := apiv1alpha3.Convert_v1beta1_APIEndpoint_To_v1alpha3_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
-	out.VIPManager = in.VIPManager
+	out.VIPManager = VIPManagerType(in.VIPManager)
 	return nil
 }
 

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -241,6 +241,7 @@ func autoConvert_v1alpha3_PacketClusterSpec_To_v1beta1_PacketClusterSpec(in *Pac
 	if err := apiv1alpha3.Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
+	out.EipManagement = in.EipManagement
 	return nil
 }
 
@@ -255,6 +256,7 @@ func autoConvert_v1beta1_PacketClusterSpec_To_v1alpha3_PacketClusterSpec(in *v1b
 	if err := apiv1alpha3.Convert_v1beta1_APIEndpoint_To_v1alpha3_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
+	out.EipManagement = in.EipManagement
 	return nil
 }
 

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -26,6 +26,9 @@ const (
 	NetworkInfrastructureReadyCondition clusterv1.ConditionType = "NetworkInfrastructureReady"
 )
 
+// VIPManagerType describes if the VIP will be managed by CPEM or kube-vip
+type VIPManagerType string
+
 // PacketClusterSpec defines the desired state of PacketCluster
 type PacketClusterSpec struct {
 	// ProjectID represents the Packet Project where this cluster will be placed into
@@ -40,7 +43,9 @@ type PacketClusterSpec struct {
 
 	// VIPManager represents whether this cluster uses CPEM or kube-vip to
 	// manage its vip for the api server IP
-	VIPManager string `json:"vipManager"`
+	// +kubebuilder:validation:Enum=CPEM;KUBE_VIP
+	// +kubebuilder:default:=CPEM
+	VIPManager VIPManagerType `json:"vipManager"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -37,6 +37,10 @@ type PacketClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// EIPManagement represents whether this cluster uses CPEM or kube-vip to
+	// manage its vip for the api server IP
+	EipManagement string `json:"eipmanagement"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -38,9 +38,9 @@ type PacketClusterSpec struct {
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
-	// EIPManagement represents whether this cluster uses CPEM or kube-vip to
+	// VIPManager represents whether this cluster uses CPEM or kube-vip to
 	// manage its vip for the api server IP
-	EipManagement string `json:"eipmanagement"`
+	VIPManager string `json:"vipManager"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -71,10 +71,10 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
-	if !reflect.DeepEqual(c.Spec.Facility, old.Spec.Facility) {
+	if !reflect.DeepEqual(c.Spec.VIPManager, old.Spec.VIPManager) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "VIPManager"),
-				c.Spec.Facility, "field is immutable"),
+				c.Spec.VIPManager, "field is immutable"),
 		)
 	}
 

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -71,6 +71,13 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
+	if !reflect.DeepEqual(c.Spec.Facility, old.Spec.Facility) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "VIPManager"),
+				c.Spec.Facility, "field is immutable"),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -61,6 +61,10 @@ spec:
                 - host
                 - port
                 type: object
+              eipmanagement:
+                description: EIPManagement represents whether this cluster uses CPEM
+                  or kube-vip to manage its vip for the api server IP
+                type: string
               facility:
                 description: Facility represents the Packet facility for this cluster
                 type: string
@@ -69,6 +73,7 @@ spec:
                   will be placed into
                 type: string
             required:
+            - eipmanagement
             - projectID
             type: object
           status:
@@ -127,6 +132,10 @@ spec:
                 - host
                 - port
                 type: object
+              eipmanagement:
+                description: EIPManagement represents whether this cluster uses CPEM
+                  or kube-vip to manage its vip for the api server IP
+                type: string
               facility:
                 description: Facility represents the Packet facility for this cluster
                 type: string
@@ -135,6 +144,7 @@ spec:
                   will be placed into
                 type: string
             required:
+            - eipmanagement
             - projectID
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -69,8 +69,12 @@ spec:
                   will be placed into
                 type: string
               vipManager:
+                default: CPEM
                 description: VIPManager represents whether this cluster uses CPEM
                   or kube-vip to manage its vip for the api server IP
+                enum:
+                - CPEM
+                - KUBE_VIP
                 type: string
             required:
             - projectID
@@ -140,8 +144,12 @@ spec:
                   will be placed into
                 type: string
               vipManager:
+                default: CPEM
                 description: VIPManager represents whether this cluster uses CPEM
                   or kube-vip to manage its vip for the api server IP
+                enum:
+                - CPEM
+                - KUBE_VIP
                 type: string
             required:
             - projectID

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -61,10 +61,6 @@ spec:
                 - host
                 - port
                 type: object
-              eipmanagement:
-                description: EIPManagement represents whether this cluster uses CPEM
-                  or kube-vip to manage its vip for the api server IP
-                type: string
               facility:
                 description: Facility represents the Packet facility for this cluster
                 type: string
@@ -72,9 +68,13 @@ spec:
                 description: ProjectID represents the Packet Project where this cluster
                   will be placed into
                 type: string
+              vipManager:
+                description: VIPManager represents whether this cluster uses CPEM
+                  or kube-vip to manage its vip for the api server IP
+                type: string
             required:
-            - eipmanagement
             - projectID
+            - vipManager
             type: object
           status:
             description: PacketClusterStatus defines the observed state of PacketCluster
@@ -132,10 +132,6 @@ spec:
                 - host
                 - port
                 type: object
-              eipmanagement:
-                description: EIPManagement represents whether this cluster uses CPEM
-                  or kube-vip to manage its vip for the api server IP
-                type: string
               facility:
                 description: Facility represents the Packet facility for this cluster
                 type: string
@@ -143,9 +139,13 @@ spec:
                 description: ProjectID represents the Packet Project where this cluster
                   will be placed into
                 type: string
+              vipManager:
+                description: VIPManager represents whether this cluster uses CPEM
+                  or kube-vip to manage its vip for the api server IP
+                type: string
             required:
-            - eipmanagement
             - projectID
+            - vipManager
             type: object
           status:
             description: PacketClusterStatus defines the observed state of PacketCluster

--- a/config/default/config.yaml
+++ b/config/default/config.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: manager-config
-  namespace: system
-data:
-  EIP_MANAGEMENT: "${EIP_MANAGEMENT:=CPEM}"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,6 @@ commonLabels:
 
 resources:
 - namespace.yaml
-- config.yaml
 - credentials.yaml
 
 bases:

--- a/config/default/manager_credentials_config_patch.yaml
+++ b/config/default/manager_credentials_config_patch.yaml
@@ -11,5 +11,3 @@ spec:
         envFrom:
         - secretRef:
             name: manager-api-credentials
-        - configMapRef:
-            name: manager-config

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -137,7 +137,7 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 		}
 	}
 
-	if clusterScope.PacketCluster.Spec.EipManagement == "KUBE_VIP" {
+	if clusterScope.PacketCluster.Spec.VIPManager == "KUBE_VIP" {
 		if err := r.PacketClient.EnableProjectBGP(packetCluster.Spec.ProjectID); err != nil {
 			log.Error(err, "error enabling bgp for project")
 			return ctrl.Result{}, err

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"errors"
-	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -138,7 +137,7 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 		}
 	}
 
-	if os.Getenv("EIP_MANAGEMENT") == "KUBE_VIP" {
+	if clusterScope.PacketCluster.Spec.EipManagement == "KUBE_VIP" {
 		if err := r.PacketClient.EnableProjectBGP(packetCluster.Spec.ProjectID); err != nil {
 			log.Error(err, "error enabling bgp for project")
 			return ctrl.Result{}, err

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -323,7 +323,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 				machineScope.Cluster.Namespace,
 				machineScope.Cluster.Name,
 				machineScope.PacketCluster.Spec.ProjectID)
-			if machineScope.PacketCluster.Spec.EipManagement == "CPEM" {
+			if machineScope.PacketCluster.Spec.VIPManager == "CPEM" {
 				if len(controlPlaneEndpoint.Assignments) == 0 {
 					a := corev1.NodeAddress{
 						Type:    corev1.NodeExternalIP,
@@ -362,7 +362,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	machineScope.SetProviderID(dev.ID)
 	machineScope.SetInstanceStatus(infrav1.PacketResourceStatus(dev.State))
 
-	if machineScope.PacketCluster.Spec.EipManagement == "KUBE_VIP" {
+	if machineScope.PacketCluster.Spec.VIPManager == "KUBE_VIP" {
 		if err := r.PacketClient.EnsureNodeBGPEnabled(dev.ID); err != nil {
 			// Do not treat an error enabling bgp on machine as fatal
 			return ctrl.Result{RequeueAfter: time.Second * 20}, fmt.Errorf("failed to enable bpg on machine %s: %w", machineScope.Name(), err)
@@ -383,7 +383,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	case infrav1.PacketResourceStatusRunning:
 		log.Info("Machine instance is active", "instance-id", machineScope.GetInstanceID())
 
-		if machineScope.PacketCluster.Spec.EipManagement == "CPEM" {
+		if machineScope.PacketCluster.Spec.VIPManager == "CPEM" {
 			controlPlaneEndpoint, _ = r.PacketClient.GetIPByClusterIdentifier(
 				machineScope.Cluster.Namespace,
 				machineScope.Cluster.Name,

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -324,7 +323,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 				machineScope.Cluster.Namespace,
 				machineScope.Cluster.Name,
 				machineScope.PacketCluster.Spec.ProjectID)
-			if os.Getenv("EIP_MANAGEMENT") == "CPEM" {
+			if machineScope.PacketCluster.Spec.EipManagement == "CPEM" {
 				if len(controlPlaneEndpoint.Assignments) == 0 {
 					a := corev1.NodeAddress{
 						Type:    corev1.NodeExternalIP,
@@ -363,7 +362,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	machineScope.SetProviderID(dev.ID)
 	machineScope.SetInstanceStatus(infrav1.PacketResourceStatus(dev.State))
 
-	if os.Getenv("EIP_MANAGEMENT") == "KUBE_VIP" {
+	if machineScope.PacketCluster.Spec.EipManagement == "KUBE_VIP" {
 		if err := r.PacketClient.EnsureNodeBGPEnabled(dev.ID); err != nil {
 			// Do not treat an error enabling bgp on machine as fatal
 			return ctrl.Result{RequeueAfter: time.Second * 20}, fmt.Errorf("failed to enable bpg on machine %s: %w", machineScope.Name(), err)
@@ -384,7 +383,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	case infrav1.PacketResourceStatusRunning:
 		log.Info("Machine instance is active", "instance-id", machineScope.GetInstanceID())
 
-		if os.Getenv("EIP_MANAGEMENT") == "CPEM" {
+		if machineScope.PacketCluster.Spec.EipManagement == "CPEM" {
 			controlPlaneEndpoint, _ = r.PacketClient.GetIPByClusterIdentifier(
 				machineScope.Cluster.Namespace,
 				machineScope.Cluster.Name,

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -189,6 +189,7 @@ kind: PacketCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
+  eipmanagement: ${EIP_MANAGEMENT:=CPEM}
   facility: ${FACILITY}
   projectID: ${PROJECT_ID}
 ---

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -189,9 +189,9 @@ kind: PacketCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  eipmanagement: ${EIP_MANAGEMENT:=CPEM}
   facility: ${FACILITY}
   projectID: ${PROJECT_ID}
+  vipManager: CPEM
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PacketMachineTemplate

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -160,6 +160,7 @@ spec:
       --interface "lo" \
       --vip "{{ .controlPlaneEndpoint }}" \
       --controlplane \
+      --services \
       --bgp \
       --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
       --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
@@ -179,6 +180,7 @@ kind: PacketCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
+  eipmanagement: ${EIP_MANAGEMENT:=KUBE_VIP}
   facility: ${FACILITY}
   projectID: ${PROJECT_ID}
 ---

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -160,7 +160,6 @@ spec:
       --interface "lo" \
       --vip "{{ .controlPlaneEndpoint }}" \
       --controlplane \
-      --services \
       --bgp \
       --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
       --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
@@ -180,9 +179,9 @@ kind: PacketCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  eipmanagement: ${EIP_MANAGEMENT:=KUBE_VIP}
   facility: ${FACILITY}
   projectID: ${PROJECT_ID}
+  vipManager: KUBE_VIP
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PacketMachineTemplate

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -114,6 +114,7 @@ metadata:
 spec:
   projectID: "${PROJECT_ID}"
   facility: "${FACILITY}"
+  eipmanagement: "${EIP_MANAGEMENT:=CPEM}"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -114,7 +114,7 @@ metadata:
 spec:
   projectID: "${PROJECT_ID}"
   facility: "${FACILITY}"
-  eipmanagement: "${EIP_MANAGEMENT:=CPEM}"
+  vipManager: "CPEM"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -19,7 +19,7 @@ patches:
     metadata:
       name: "${CLUSTER_NAME}"
     spec:
-      eipmanagement: "${EIP_MANAGEMENT:=KUBE_VIP}"
+      vipManager: "KUBE_VIP"
 - patch: |
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -62,7 +62,6 @@ patches:
             --interface "lo" \
             --vip "{{ .controlPlaneEndpoint }}" \
             --controlplane \
-            --services \
             --bgp \
             --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
             --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -13,6 +13,13 @@ patches:
         cni: "${CLUSTER_NAME}-kube-vip"
   target:
     kind: Cluster
+- patch: |-
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: PacketCluster
+    metadata:
+      name: "${CLUSTER_NAME}"
+    spec:
+      eipmanagement: "${EIP_MANAGEMENT:=KUBE_VIP}"
 - patch: |
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -55,6 +62,7 @@ patches:
             --interface "lo" \
             --vip "{{ .controlPlaneEndpoint }}" \
             --controlplane \
+            --services \
             --bgp \
             --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
             --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \


### PR DESCRIPTION
Convert to having the EIP_MANAGEMENT variable as part of the packetcluster Type

This is my attempt to implement what we discussed in Slack. I've moved the variable controlling whether we use kube-vip or CPEM into a field in the PacketCluster Type.